### PR TITLE
Adding PDM enabled message queue

### DIFF
--- a/Common/Messages.h
+++ b/Common/Messages.h
@@ -9,10 +9,12 @@
 #define WM_PROCESSCOPYDATA          WM_USER + 2
 #define WM_SET_MESSAGE_HWND         WM_USER + 3 // WPARAM is BSTR (id), LPARAM is HWND
 
-#define WM_MESSAGE_RECEIVE          WM_USER + 4 // WPARAM is BSTR (MessageInfo), LPARAM is NULL
+#define WM_MESSAGE_RECEIVE          WM_USER + 4 // WPARAM is BSTR (MessagePacket), LPARAM is NULL
 #define WM_MESSAGE_SEND             WM_USER + 5 // WPARAM is BSTR (data), LPARAM is NULL
+#define WM_MESSAGE_IN_QUEUE         WM_USER + 6
 
-#define WM_CREATE_ENGINE            WM_USER + 6 // WPARAM is BSTR (id), LPARAM is NULL
+#define WM_CREATE_ENGINE            WM_USER + 7 // WPARAM is BSTR (id), LPARAM is NULL
+#define WM_BREAK_OCCURRED           WM_USER + 8
 
 // Messages used across processes
 UINT Get_WM_SET_CONNECTION_HWND();              // WPARAM is HWND (connectBackTo), LPARAM is NULL
@@ -24,11 +26,11 @@ enum class MessageType
     ExecuteAtBreak
 };
 
-struct MessageInfo
+struct MessagePacket
 {
+    MessageType m_messageType;
     CComBSTR m_engineId;
     CComBSTR m_scriptName;
-    MessageType m_messageType;
     CComBSTR m_message;
 };
 

--- a/IEWebkitImpl/Browser.ts
+++ b/IEWebkitImpl/Browser.ts
@@ -18,6 +18,10 @@ module F12.Proxy {
             this.windowExternal.addEventListener("message", (e: any) => this.messageHandler(e));
         }
 
+        private alert(message: string): void {
+            this.windowExternal.sendMessage("alert", message);
+        }
+
         private PostResponse(id: number, value: IWebKitResult) {
             // Send the response back over the websocket
             var response: IWebKitResponse = Common.CreateResponse(id, value);

--- a/IEWebkitImpl/debugger.ts
+++ b/IEWebkitImpl/debugger.ts
@@ -271,8 +271,8 @@ module F12.Proxy {
                             this.PostResponse(request.id, r);
                             break;
                         }
-                        this.PostResponse(request.id, {});
-                        break;
+
+                        return host.postMessageToEngine("browser", this._isAtBreakpoint, JSON.stringify(request));
                 }
             }
         }

--- a/Proxy/BrowserHost.h
+++ b/Proxy/BrowserHost.h
@@ -26,8 +26,6 @@ public:
     END_COM_MAP()
 
     BEGIN_MSG_MAP(BrowserHost)
-        MESSAGE_HANDLER(WM_SET_MESSAGE_HWND, OnSetMessageHwnd)
-        MESSAGE_HANDLER(WM_MESSAGE_RECEIVE, OnMessageReceived)
     END_MSG_MAP()
 
     BEGIN_SINK_MAP(BrowserHost)
@@ -38,14 +36,12 @@ public:
     STDMETHOD(OnMessage)(_In_reads_(ulDataCount)  LPCWSTR* pszData, ULONG ulDataCount);
     STDMETHOD(OnScriptError)(_In_ IActiveScriptError* pScriptError);
 
-    // Window Messages
-    LRESULT OnSetMessageHwnd(UINT nMsg, WPARAM wParam, LPARAM lParam, _Inout_ BOOL& /*bHandled*/);
-    LRESULT OnMessageReceived(UINT nMsg, WPARAM wParam, LPARAM lParam, _Inout_ BOOL& /*bHandled*/);
-
     // DWebBrowserEvents2
     STDMETHOD_(void, DWebBrowserEvents2_NavigateComplete2)(LPDISPATCH pDisp, VARIANT * URL);
 
     HRESULT Initialize(_In_ HWND proxyHwnd, _In_ IUnknown* pWebControl);
+    HRESULT SetWebSocketHwnd(_In_ HWND websocketHwnd);
+    HRESULT ProcessMessage(_In_ shared_ptr<MessagePacket> spPacket);
 
 private:
     HRESULT OnNavigateCompletePrivate(_In_ CComPtr<IUnknown>& spUnknown, _In_ CString& url);

--- a/Proxy/BrowserMessageQueue.cpp
+++ b/Proxy/BrowserMessageQueue.cpp
@@ -1,0 +1,367 @@
+//
+// Copyright (C) Microsoft. All rights reserved.
+//
+
+#include "stdafx.h"
+#include "BrowserMessageQueue.h"
+
+BrowserMessageQueue::BrowserMessageQueue() :
+    m_isAppAdvised(false),
+    m_isThreadAdvised(false),
+    m_isValid(false),
+    m_notifyOnBreak(false),
+    m_appCookie(0),
+    m_threadCookie(0),
+    m_messageWindow(NULL),
+    m_safeToEvalScriptDuringDebugThreadCall(true)
+{
+}
+
+void BrowserMessageQueue::Initialize(_In_ IDebugApplication110* pDebugApplication, _In_ IDebugThreadCall* pCall, _In_ HWND messageWnd, bool notifyOnBreak)
+{
+    m_spDebugApplication = pDebugApplication;
+    m_spCall = pCall;
+    m_messageWindow = messageWnd;
+    m_notifyOnBreak = notifyOnBreak;
+
+    // Must be called on the browser ui thread
+    m_mainThreadId = ::GetCurrentThreadId();
+
+    if (pDebugApplication)
+    {
+        HRESULT hr = ::AtlAdvise(m_spDebugApplication, GetUnknown(), IID_IRemoteDebugApplicationEvents, &m_appCookie);
+        ATLASSERT(hr == S_OK);
+        if (hr == S_OK) 
+        { 
+            m_isAppAdvised = true; 
+        }
+
+        this->TryMainThreadAdvise();
+    }
+
+    m_isValid = true;
+}
+
+void BrowserMessageQueue::Deinitialize()
+{
+    if (m_isValid)
+    {
+        // Should be deinitialized on the browser ui thread
+        ATLASSERT(::GetCurrentThreadId() == m_mainThreadId);
+
+        // Scope for the objects lock
+        {
+            CComCritSecLock<CComAutoCriticalSection> lock(m_csCOMObjects);
+            m_isValid = false;
+            if (m_isAppAdvised)
+            {
+                HRESULT hr = ::AtlUnadvise(m_spDebugApplication, IID_IRemoteDebugApplicationEvents, m_appCookie);
+                ATLASSERT(hr == S_OK); hr;
+            }
+
+            if (m_isThreadAdvised)
+            {
+                CComPtr<IRemoteDebugApplicationThread> spMainThread;
+                HRESULT hr = m_spDebugApplication->GetMainThread(&spMainThread);
+                if (spMainThread != nullptr)
+                {
+                    hr = ::AtlUnadvise(spMainThread, __uuidof(IDebugApplicationThreadEvents110), m_threadCookie);
+                    ATLASSERT(hr == S_OK); hr;
+                }
+            }
+
+            m_spCall.Release();
+            m_spDebugApplication.Release();
+            m_messageWindow = nullptr;
+        }
+
+        // Scope for the messages lock
+        {
+            CComCritSecLock<CComAutoCriticalSection> lock2(m_csMessageArray);
+            m_messages.clear();
+        }
+    }
+}
+
+void BrowserMessageQueue::Push(_In_ shared_ptr<MessagePacket> spMessage)
+{
+    // Scope for the messages lock
+    {
+        CComCritSecLock<CComAutoCriticalSection> lock(m_csMessageArray);
+        m_messages.push_back(spMessage);
+    }
+
+    HRESULT hr = this->TriggerThreadCall();
+    if (hr != S_OK)
+    {
+        this->PostProcessPacketsMessage();
+    }
+}
+
+void BrowserMessageQueue::PopAll(_Inout_ vector<shared_ptr<MessagePacket>>& messages)
+{
+    CComCritSecLock<CComAutoCriticalSection> lock(m_csMessageArray);
+
+    messages.assign(m_messages.begin(), m_messages.end());
+    m_messages.clear();
+}
+
+void BrowserMessageQueue::Remove(_In_ const shared_ptr<MessagePacket>& spMessage)
+{
+    CComCritSecLock<CComAutoCriticalSection> lock(m_csMessageArray);
+
+    auto packetIt = find(m_messages.cbegin(), m_messages.cend(), spMessage);
+    if (packetIt != m_messages.end())
+    {
+        m_messages.erase(packetIt);
+    }
+}
+
+BOOL BrowserMessageQueue::PostProcessPacketsMessage(bool postIfAny)
+{
+    if (!m_isValid)
+    {
+        // It's possible for the message queue to contain messages after it is released. 
+        // Simply ignore the messages as the queue finishes up.
+        return FALSE;
+    }
+
+    vector<shared_ptr<MessagePacket>>::size_type size;
+
+    // Scope for the lock
+    {
+        CComCritSecLock<CComAutoCriticalSection> lock(m_csMessageArray);
+        size = m_messages.size();
+    }
+
+    // We only need to post a message to the other thread if either:
+    // This is the first item placed in the queue 
+    // - OR -
+    // The queue has had several items placed in it without processing, due to being at a breakpoint
+    if (size == 1 || (postIfAny && size > 0))
+    {
+        return ::PostMessage(m_messageWindow, WM_MESSAGE_IN_QUEUE, NULL, NULL);
+    }
+
+    return TRUE;
+}
+
+HRESULT BrowserMessageQueue::AsyncCallOnMainThread(DWORD_PTR messageID)
+{
+    if (m_spDebugApplication && m_spCall && m_safeToEvalScriptDuringDebugThreadCall)
+    {
+        CComCritSecLock<CComAutoCriticalSection> lock(m_csCOMObjects);
+
+        if (m_spDebugApplication && m_spCall)
+        {
+            this->TryMainThreadAdvise();
+
+            CComPtr<IRemoteDebugApplicationThread> spRemoteThread;
+            HRESULT hr = m_spDebugApplication->GetMainThread(&spRemoteThread);
+            if (hr != S_OK) { return hr; }
+
+            CComQIPtr<IDebugApplicationThread110> spThread110(spRemoteThread);
+            ATLENSURE_RETURN_HR(spThread110.p != NULL, E_NOINTERFACE);
+
+            BOOL isCallable;
+            hr = spThread110->IsThreadCallable(&isCallable);
+            if (hr != S_OK) { return hr; }
+
+            if (isCallable)
+            {
+                // Make sure we only issue the call while suspended at a breakpoint.
+                // If we're not suspended, the call will be made in response to the suspended event.
+                BOOL isSuspendedForBreak;
+                hr = spThread110->IsSuspendedForBreakPoint(&isSuspendedForBreak);
+                ATLENSURE_RETURN_HR(hr == S_OK, hr);
+
+                if (isSuspendedForBreak)
+                {
+                    UINT cRequestsActive;
+                    hr = spThread110->GetActiveThreadRequestCount(&cRequestsActive);
+
+                    if (cRequestsActive > 0)
+                    {
+                        // Returning S_OK if there's an active request because we don't need to post message - 
+                        // we'll requeue during OnThreadRequestComplete for that request
+                        return S_OK;
+                    }
+
+                    CComObject<PassthroughDebugThreadCall>* pPassthroughDebugThreadCall;
+                    hr = CComObject<PassthroughDebugThreadCall>::CreateInstance(&pPassthroughDebugThreadCall);
+                    ATLENSURE_RETURN_HR(hr == S_OK, hr);
+
+                    CComQIPtr<IDebugThreadCall> spDebugThreadCall(pPassthroughDebugThreadCall);
+                    ATLENSURE_RETURN_HR(spDebugThreadCall.p != NULL, E_NOINTERFACE);
+
+                    pPassthroughDebugThreadCall->Initialize(spThread110, m_spCall, messageID);
+
+                    hr = spThread110->AsynchronousCallIntoThread(spDebugThreadCall, NULL, NULL, NULL);
+                    return hr;
+                }
+            }
+        }
+    }
+
+    return S_FALSE;
+}
+
+HRESULT BrowserMessageQueue::TriggerThreadCall()
+{
+    return this->AsyncCallOnMainThread(WM_MESSAGE_IN_QUEUE);
+}
+
+void BrowserMessageQueue::NotifyBreakOccurred()
+{
+    this->AsyncCallOnMainThread(WM_BREAK_OCCURRED);
+}
+
+STDMETHODIMP BrowserMessageQueue::OnEnterBreakPoint(__RPC__in_opt IRemoteDebugApplicationThread* prdat)
+{
+    // It's unsafe to evaluate script until onsuspendforbreakpoint is called since the debugger will be in an odd state.
+    if (prdat)
+    {
+        DWORD applicationThread;
+        HRESULT hr = prdat->GetSystemThreadId(&applicationThread);
+        ATLASSERT(hr == S_OK);
+        if (hr == S_OK && applicationThread == m_mainThreadId)
+        {
+            this->TryMainThreadAdvise();
+            m_safeToEvalScriptDuringDebugThreadCall = false;
+        }
+    }
+
+    return S_OK;
+}
+
+STDMETHODIMP BrowserMessageQueue::OnSuspendForBreakPoint()
+{
+    // This means the debugger has fully processed the breakpoint and is ready for things to happen.  
+    // So, let's call process messageswithdebugger to see if we need to execute anything now that it's safe to do so.
+    m_safeToEvalScriptDuringDebugThreadCall = true;
+    
+    this->ProcessMessagesWithDebugger();
+
+    if (m_notifyOnBreak)
+    {
+        this->NotifyBreakOccurred();
+    }
+
+    return S_OK;
+}
+
+void BrowserMessageQueue::ProcessMessagesWithDebugger()
+{
+    bool shouldProcessMessages = false;
+
+    // Determine the main thread id and the thread id that just broke. 
+    // If they match, we need to process remaining messages that might 
+    // have been post messaged but never processed.
+
+    if (m_spDebugApplication && m_spCall)
+    {
+        DWORD eventThreadId = ::GetCurrentThreadId();
+
+        if (eventThreadId == m_mainThreadId)
+        {
+            size_t cMessages = 0;
+
+            // Scope for lock
+            {
+                CComCritSecLock<CComAutoCriticalSection> lock(m_csMessageArray);
+                cMessages = m_messages.size();
+            }
+
+            if (cMessages != 0)
+            {
+                shouldProcessMessages = true;
+            }
+        }
+    }
+
+    if (shouldProcessMessages)
+    {
+        // Need to make sure anything still in the post message queue makes it
+        // This call could fail to switch the the PDM thread and return S_FALSE, 
+        // But in that case it must be because we have resumed from the breakpoint, 
+        // So OnResumeFromBreakPoint will ensure we message the other thread to clear its queue.
+        this->TriggerThreadCall();
+    }
+}
+
+STDMETHODIMP BrowserMessageQueue::OnResumeFromBreakPoint()
+{
+    // Since several items may have been added into the queue without the PDM being ready to switch to the other thread,
+    // We need to force a message to the other thread if there are any items in the queue at all.
+    this->PostProcessPacketsMessage(/*postIfAny=*/true);
+
+    return S_OK;
+}
+
+STDMETHODIMP BrowserMessageQueue::OnThreadRequestComplete()
+{
+    this->ProcessMessagesWithDebugger();
+
+    return S_OK;
+}
+
+STDMETHODIMP BrowserMessageQueue::OnBeginThreadRequest()
+{
+    return S_OK;
+}
+
+STDMETHODIMP BrowserMessageQueue::OnLeaveBreakPoint(__RPC__in_opt IRemoteDebugApplicationThread* prdat)
+{
+    // Determine the main thread id and the thread id that just resumed. 
+    // If they match, we need to process remaining messages that might 
+    // have been queued for break mode processing but never processed.
+
+    if (prdat)
+    {
+        DWORD eventThreadId;
+
+        HRESULT hr = prdat->GetSystemThreadId(&eventThreadId);
+        ATLENSURE_RETURN_HR(hr == S_OK, S_OK);
+
+        if (eventThreadId == m_mainThreadId)
+        {
+            m_safeToEvalScriptDuringDebugThreadCall = true;
+
+            // Scope for lock
+            {
+                CComCritSecLock<CComAutoCriticalSection> lock(m_csCOMObjects);
+                if (m_messageWindow != NULL)
+                {
+                    // Queue a windows message to be process any remaining messages when the thread resumes
+                    ::PostMessage(m_messageWindow, WM_MESSAGE_IN_QUEUE, NULL, NULL);
+                }
+            }
+        }
+    }
+    return S_OK;
+}
+
+void BrowserMessageQueue::TryMainThreadAdvise()
+{
+    // Sometimes the main thread hasn't been activated in the PDM yet when we are initialized.
+    // So we call this both when we first initialize, but also when we receive an enter break point event on an 
+    // application thread to make sure we get a chance to advise before we enter break mode.
+    if (m_isThreadAdvised) { return; }
+
+    if (m_spDebugApplication.p != NULL)
+    {
+        CComPtr<IRemoteDebugApplicationThread> spThread;
+        HRESULT hr = m_spDebugApplication->GetMainThread(&spThread);
+        if (hr == S_OK)
+        {
+            hr = ::AtlAdvise(spThread, GetUnknown(), __uuidof(IDebugApplicationThreadEvents110), &m_threadCookie);
+            ATLASSERT(hr == S_OK);
+
+            if (hr == S_OK) 
+            { 
+                m_isThreadAdvised = true; 
+            }
+        }
+    }
+}
+

--- a/Proxy/BrowserMessageQueue.h
+++ b/Proxy/BrowserMessageQueue.h
@@ -1,0 +1,134 @@
+//
+// Copyright (C) Microsoft. All rights reserved.
+//
+
+#pragma once
+
+#include <activdbg100.h>
+
+class ATL_NO_VTABLE BrowserMessageQueue :
+    public CComObjectRootEx<CComMultiThreadModel>,
+    public IRemoteDebugApplicationEvents,
+    public IDebugApplicationThreadEvents110
+{
+public:
+    BEGIN_COM_MAP(BrowserMessageQueue)
+        COM_INTERFACE_ENTRY(IRemoteDebugApplicationEvents)
+        COM_INTERFACE_ENTRY(IDebugApplicationThreadEvents110)
+    END_COM_MAP()
+
+    BrowserMessageQueue();
+
+    // IRemoteDebugApplicationEvents
+    STDMETHOD(OnConnectDebugger)(__RPC__in_opt IApplicationDebugger* pad) { return S_OK; }
+    STDMETHOD(OnDisconnectDebugger)() { return S_OK; }
+    STDMETHOD(OnSetName)(__RPC__in LPCOLESTR pstrName) { return S_OK; }
+    STDMETHOD(OnDebugOutput)(__RPC__in LPCOLESTR pstr) { return S_OK; }
+    STDMETHOD(OnClose)() { return S_OK; }
+    STDMETHOD(OnEnterBreakPoint)(__RPC__in_opt IRemoteDebugApplicationThread* prdat);
+    STDMETHOD(OnLeaveBreakPoint)(__RPC__in_opt IRemoteDebugApplicationThread* prdat);
+    STDMETHOD(OnCreateThread)(__RPC__in_opt IRemoteDebugApplicationThread* prdat) { return S_OK; }
+    STDMETHOD(OnDestroyThread)(__RPC__in_opt IRemoteDebugApplicationThread* prdat) { return S_OK; }
+    STDMETHOD(OnBreakFlagChange)(APPBREAKFLAGS abf, __RPC__in_opt IRemoteDebugApplicationThread* prdatSteppingThread) { return S_OK; }
+
+    // IDebugApplicationThreadEvents110
+    STDMETHOD(OnSuspendForBreakPoint)();
+    STDMETHOD(OnResumeFromBreakPoint)();
+    STDMETHOD(OnThreadRequestComplete)();
+    STDMETHOD(OnBeginThreadRequest)();
+
+    void Initialize(_In_ IDebugApplication110* pDebugApplication, _In_ IDebugThreadCall* pCall, _In_ HWND messageWnd, bool notifyOnBreak);
+    void Deinitialize();
+    void NotifyBreakOccurred();
+    void Push(_In_ shared_ptr<MessagePacket> spMessage);
+    void PopAll(_Inout_ vector<shared_ptr<MessagePacket>>& messages);
+    BOOL PostProcessPacketsMessage(bool postIfAny = false);
+    void Remove(_In_ const shared_ptr<MessagePacket>& spMessage);
+    HRESULT TriggerThreadCall();
+
+private:
+    class ATL_NO_VTABLE PassthroughDebugThreadCall :
+        public CComObjectRootEx<CComMultiThreadModel>,
+        public IDebugThreadCall
+    {
+    public:
+        BEGIN_COM_MAP(PassthroughDebugThreadCall)
+            COM_INTERFACE_ENTRY(IDebugThreadCall)
+        END_COM_MAP()
+
+        void Initialize(_In_ IDebugApplicationThread110* pTarget, _In_ IDebugThreadCall* pReceiver, DWORD_PTR messageID)
+        {
+            m_spDebugApplicationThreadTarget = pTarget;
+            m_spReceiver = pReceiver;
+            m_messageID = messageID;
+        }
+
+        STDMETHOD(ThreadCallHandler)(
+            /* [in] */ DWORD_PTR /*dwParam1*/,
+            /* [in] */ DWORD_PTR /*dwParam2*/,
+            /* [in] */ DWORD_PTR /*dwParam3*/) override
+        {
+            // Now we're running on the main browser UI thread through the PDM's thread call mechanisms.  
+            // Before actually forwarding any messages (which might end up executing JavaScript), we need to check that it's safe to do so. 
+            // We must ensure that:
+            // 1. No other messages are already executing and that the thread
+            // 2. The thread is actually still suspended for a breakpoint and not at some other stage that triggered a thread switch allowing us to run.
+            // In either case, we'll get a chance to requeue again either during the SuspendForBreakPoint event, the resumefrombreakpoint event (where we postmessage),
+            // or in the ThreadRequestComplete event.
+
+            ATLENSURE_RETURN_HR(m_spReceiver.p != NULL, E_NOT_VALID_STATE);
+            ATLENSURE_RETURN_HR(m_spDebugApplicationThreadTarget.p != NULL, E_NOT_VALID_STATE);
+
+            BOOL suspendedForBreakPoint;
+            HRESULT hr = m_spDebugApplicationThreadTarget->IsSuspendedForBreakPoint(&suspendedForBreakPoint);
+            ATLENSURE_RETURN_HR(hr == S_OK, hr);
+
+            if (suspendedForBreakPoint)
+            {
+                UINT uiCount;
+                hr = m_spDebugApplicationThreadTarget->GetActiveThreadRequestCount(&uiCount);
+                ATLENSURE_RETURN_HR(hr == S_OK, hr);
+
+                ATLASSERT(uiCount >= 1);
+
+                // If uiCount is 1, only we are running.  
+                // If it's greater than 1, we are running but so is something else. 
+                // We will get picked up again when we handle the threadrequestcomplete event and execute then.
+                if (uiCount <= 1)
+                {
+                    return m_spReceiver->ThreadCallHandler(m_messageID, NULL, NULL);
+                }
+            }
+
+            return S_FALSE;
+        }
+
+    private:
+        CComPtr<IDebugApplicationThread110> m_spDebugApplicationThreadTarget;
+        CComPtr<IDebugThreadCall> m_spReceiver;
+        DWORD_PTR m_messageID;
+    };
+
+    HRESULT AsyncCallOnMainThread(DWORD_PTR messageID);
+    void TryMainThreadAdvise();
+    void ProcessMessagesWithDebugger();
+
+private:
+    CComAutoCriticalSection m_csCOMObjects;
+    CComAutoCriticalSection m_csMessageArray;
+    vector<shared_ptr<MessagePacket>> m_messages;
+    CComPtr<IDebugApplication110> m_spDebugApplication;
+    CComPtr<IDebugThreadCall> m_spCall;
+
+    bool m_isValid;
+    bool m_isAppAdvised;
+    bool m_isThreadAdvised;
+    bool m_notifyOnBreak;
+    volatile bool m_safeToEvalScriptDuringDebugThreadCall;
+
+    DWORD m_appCookie;
+    DWORD m_threadCookie;
+    DWORD m_mainThreadId;
+    HWND m_messageWindow;
+};
+

--- a/Proxy/DebuggerHost.cpp
+++ b/Proxy/DebuggerHost.cpp
@@ -104,16 +104,16 @@ JsValueRef DebuggerHost::postMessageToEngine(JsValueRef callee, bool isConstruct
         size_t dataLength;
         jec = ::JsStringToPointer(arguments[3], &data, &dataLength);
 
-        unique_ptr<MessageInfo> spInfo(new MessageInfo());
-        spInfo->m_engineId = id;
-        spInfo->m_messageType = (isAtBreakpoint ? MessageType::ExecuteAtBreak : MessageType::Execute);
-        spInfo->m_message = data;
+        unique_ptr<MessagePacket> spPacket(new MessagePacket());
+        spPacket->m_engineId = id;
+        spPacket->m_messageType = (isAtBreakpoint ? MessageType::ExecuteAtBreak : MessageType::Execute);
+        spPacket->m_message = data;
 
-        MessageInfo* pInfoParam = spInfo.release();
-        BOOL succeeded = ::PostMessage(m_websocketHwnd, WM_MESSAGE_RECEIVE, reinterpret_cast<WPARAM>(pInfoParam), NULL);
+        MessagePacket* pPacketParam = spPacket.release();
+        BOOL succeeded = ::PostMessage(m_websocketHwnd, WM_MESSAGE_RECEIVE, reinterpret_cast<WPARAM>(pPacketParam), NULL);
         if (!succeeded)
         {
-            spInfo.reset(pInfoParam);
+            spPacket.reset(pPacketParam);
         }
     }
 

--- a/Proxy/Proxy.vcxproj
+++ b/Proxy/Proxy.vcxproj
@@ -109,6 +109,7 @@
     <ClInclude Include="DebuggerHost.h" />
     <ClInclude Include="dllmain.h" />
     <ClInclude Include="JsWrappers.h" />
+    <ClInclude Include="BrowserMessageQueue.h" />
     <ClInclude Include="ProxySite.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="ScriptEngineHost.h" />
@@ -125,6 +126,7 @@
     <ClCompile Include="BrowserHost.cpp" />
     <ClCompile Include="DebuggerHost.cpp" />
     <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="BrowserMessageQueue.cpp" />
     <ClCompile Include="ProxySite.cpp" />
     <ClCompile Include="ScriptEngineHost.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/Proxy/Proxy.vcxproj.filters
+++ b/Proxy/Proxy.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="WebSocketClientHost.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="BrowserMessageQueue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -69,6 +72,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="WebSocketClientHost.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="BrowserMessageQueue.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Proxy/ProxySite.h
+++ b/Proxy/ProxySite.h
@@ -6,6 +6,7 @@
 #include "Proxy_h.h"
 #include "../DebuggerCore/DebugThreadWindowMessages.h"
 #include "BrowserHost.h"
+#include "BrowserMessageQueue.h"
 
 struct ThreadParams
 {
@@ -14,19 +15,22 @@ struct ThreadParams
     shared_ptr<HWND> m_spHwnd;
     HWND m_mainHwnd;
     CComPtr<IUnknown> m_spUnknown;
+    CComObjPtr<BrowserMessageQueue> m_spMessageQueue;
 
     ThreadParams(
         _In_ HANDLE hEvent,
         _In_ shared_ptr<HRESULT> spResult,
         _In_ shared_ptr<HWND> spHwnd,
         _In_ HWND mainHwnd,
-        _In_opt_ IUnknown* pUnknown)
+        _In_opt_ IUnknown* pUnknown,
+        _In_opt_ BrowserMessageQueue* pMessageQueue)
         :
         m_hEvent(hEvent),
         m_spResult(spResult),
         m_spHwnd(spHwnd),
         m_mainHwnd(mainHwnd),
-        m_spUnknown(pUnknown)
+        m_spUnknown(pUnknown),
+        m_spMessageQueue(pMessageQueue)
     { }
 };
 
@@ -47,11 +51,12 @@ struct ThreadInfo
 };
 
 class ProxySite :
-    public CComObjectRootEx<CComSingleThreadModel>,
+    public CComObjectRootEx<CComMultiThreadModel>,
     public CComCoClass<ProxySite, &CLSID_ProxySite>,
     public IObjectWithSiteImpl<ProxySite>,
     public CWindowImpl<ProxySite>,
     public IOleWindow,
+    public IDebugThreadCall,
     public IProxySite
 {
 public:
@@ -61,10 +66,12 @@ public:
     BEGIN_COM_MAP(ProxySite)
         COM_INTERFACE_ENTRY(IObjectWithSite)
         COM_INTERFACE_ENTRY(IOleWindow)
+        COM_INTERFACE_ENTRY(IDebugThreadCall)
         COM_INTERFACE_ENTRY(IProxySite)
     END_COM_MAP()
 
     BEGIN_MSG_MAP(ProxySite)
+        MESSAGE_HANDLER(WM_MESSAGE_IN_QUEUE, OnMessageInQueue)
         MESSAGE_HANDLER(WM_CREATE_ENGINE, OnCreateEngine)
         MESSAGE_RANGE_HANDLER(WM_CONTROLLERCOMMAND_FIRST, WM_CONTROLLERCOMMAND_LAST, OnControllerCommand)
     END_MSG_MAP()
@@ -79,20 +86,28 @@ public:
     STDMETHOD(GetWindow)(__RPC__deref_out_opt HWND* pHwnd);
     STDMETHOD(ContextSensitiveHelp)(BOOL fEnterMode) { return E_NOTIMPL; }
 
+    // IDebugThreadCall
+    STDMETHOD(ThreadCallHandler)(_In_ DWORD_PTR dwParam1, _In_ DWORD_PTR dwParam2, _In_ DWORD_PTR dwParam3);
+
     // Window Messages
+    LRESULT OnMessageInQueue(UINT nMsg, WPARAM wParam, LPARAM lParam, _Inout_ BOOL& /*bHandled*/);
     LRESULT OnCreateEngine(UINT nMsg, WPARAM wParam, LPARAM lParam, _Inout_ BOOL& /*bHandled*/);
     LRESULT OnControllerCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, _Inout_ BOOL& /*bHandled*/);
 
 private:
-    HRESULT CreateThread(_In_ HWND mainHwnd, _In_opt_ IUnknown* pUnknown, _In_ LPTHREAD_START_ROUTINE threadProc, _Out_ DWORD& threadId, _Out_ CHandle& threadHandle, _Out_ HWND& threadMessageHwnd);
+    HRESULT CreateThread(_In_ HWND mainHwnd, _In_opt_ IUnknown* pUnknown, _In_opt_ BrowserMessageQueue* pMessageQueue, _In_ LPTHREAD_START_ROUTINE threadProc, _Out_ DWORD& threadId, _Out_ CHandle& threadHandle, _Out_ HWND& threadMessageHwnd);
+    HRESULT EnableSourceRundown(_Out_ CComPtr<IRemoteDebugApplication>& spRemoteDebugApplication);
     HRESULT EnableDynamicDebugging(_Out_ CComPtr<IRemoteDebugApplication>& spRemoteDebugApplication);
+    HRESULT LoadPDM(_In_ DWORD attachType, _Out_ CComPtr<IRemoteDebugApplication>& spRemoteDebugApplication);
     HRESULT IOleCommandTargetExec(_In_ DWORD cmdId, _Inout_ CComPtr<IDispatch>& spDispatch, _Inout_ CComVariant& spResult);
+    HRESULT CreateEngine(_In_ CComBSTR& id);
 
 private:
     ThreadInfo m_websocketThread;
     ThreadInfo m_debuggerThread;
 
     map<CComBSTR, CComPtr<BrowserHost>> m_browserEngines;
+    CComObjPtr<BrowserMessageQueue> m_spMessageQueue;
 };
 
 OBJECT_ENTRY_AUTO(__uuidof(ProxySite), ProxySite)

--- a/Proxy/ScriptEngineHost.cpp
+++ b/Proxy/ScriptEngineHost.cpp
@@ -108,7 +108,7 @@ LRESULT ScriptEngineHost::OnSetMessageHwnd(UINT nMsg, WPARAM wParam, LPARAM lPar
 LRESULT ScriptEngineHost::OnMessageReceived(UINT nMsg, WPARAM wParam, LPARAM lParam, _Inout_ BOOL& /*bHandled*/)
 {
     // Take ownership of the data
-    unique_ptr<MessageInfo> spInfo(reinterpret_cast<MessageInfo*>(wParam));
+    unique_ptr<MessagePacket> spPacket(reinterpret_cast<MessagePacket*>(wParam));
 
     JsErrorCode jec = JsNoError;
 
@@ -117,10 +117,10 @@ LRESULT ScriptEngineHost::OnMessageReceived(UINT nMsg, WPARAM wParam, LPARAM lPa
         JsContextPtr context(m_scriptContext);
 
         // Check if this is a script injection message
-        if (spInfo->m_messageType == MessageType::Inject)
+        if (spPacket->m_messageType == MessageType::Inject)
         {
             // Execute the script so it gets injected into our Chakra runtime
-            this->ExecuteScript(spInfo->m_scriptName, spInfo->m_message);
+            this->ExecuteScript(spPacket->m_scriptName, spPacket->m_message);
 
             // Done
             return 0;
@@ -129,7 +129,7 @@ LRESULT ScriptEngineHost::OnMessageReceived(UINT nMsg, WPARAM wParam, LPARAM lPa
         // Otherwise we fire the 'onmessage' event to any functions that are listening
         const WORD argCount = 1;
         JsValueRef args[argCount];
-        jec = ::JsPointerToString(spInfo->m_message.m_str, spInfo->m_message.Length(), &args[0]);
+        jec = ::JsPointerToString(spPacket->m_message.m_str, spPacket->m_message.Length(), &args[0]);
         //ATLASSERT(jec == JsNoError);
 
         if (jec != JsNoError)

--- a/Proxy/WebSocketClientHost.h
+++ b/Proxy/WebSocketClientHost.h
@@ -6,6 +6,7 @@
 
 #include "Proxy_h.h"
 #include "ScriptEngineHost.h"
+#include "BrowserMessageQueue.h"
 
 class WebSocketClientHost :
     public ScriptEngineHost
@@ -31,18 +32,18 @@ public:
     LRESULT OnCopyData(UINT nMsg, WPARAM wParam, LPARAM lParam, _Inout_ BOOL& /*bHandled*/);
     LRESULT OnMessageFromWebKit(UINT nMsg, WPARAM wParam, LPARAM lParam, _Inout_ BOOL& /*bHandled*/);
 
-    HRESULT Initialize(_In_ HWND mainHwnd);
+    HRESULT Initialize(_In_ HWND mainHwnd, _In_ BrowserMessageQueue* pMessageQueue);
 
 private:
     // Helper functions
-    HRESULT SendMessageToScriptHost(_In_ unique_ptr<MessageInfo>&& spInfo, _In_ bool shouldCreateEngine);
+    HRESULT SendMessageToThreadEngine(_In_ unique_ptr<MessagePacket>&& spPacket, _In_ bool shouldCreateEngine);
     HRESULT SendMessageToWebKit(_In_ CString& message);
 
 private:
     HWND m_uiThreadHwnd;
     HWND m_serverHwnd;
-
-    map<CString, HWND> m_engineHosts;
-    map<CString, vector<unique_ptr<MessageInfo>>> m_engineMessageQueue;
+    CComObjPtr<BrowserMessageQueue> m_spBrowserMessageQueue;
+    map<CComBSTR, HWND> m_threadEngineHosts;
+    map<CComBSTR, vector<unique_ptr<MessagePacket>>> m_threadEngineMessageQueue;
 };
 


### PR DESCRIPTION
- The websocket thread now uses a message queue object to send messages to the browser ui thread
- The message queue uses the PDM to marshal messages on the the UI thread when it is blocked at a breakpoint
- This allows javascript engine running on the ui thread to process messages even while at a breakpoint