### PR TITLE
Escape special characters in target list JSON string.

### DIFF
--- a/Common/Helpers.cpp
+++ b/Common/Helpers.cpp
@@ -258,4 +258,37 @@ namespace Helpers
         }
         return hr;
     }
+
+    CStringA EscapeJsonString(const CString& value)
+    {
+        CStringA escapedValue;
+
+        for (auto i = 0; i < value.GetLength(); i++)
+        {
+            auto c = value[i];
+            if (c > 126)
+            {
+                CStringA charLiteral;
+                charLiteral.Format("\\u%04x", c);
+                escapedValue.Append(charLiteral);
+            }
+            else
+            {
+                switch (c)
+                {
+                    case '\\': escapedValue.Append("\\\\"); break;
+                    case '\"': escapedValue.Append("\\\""); break;
+                    case '/': escapedValue.Append("\\/"); break;
+                    case '\b': escapedValue.Append("\\b"); break;
+                    case '\f': escapedValue.Append("\\f"); break;
+                    case '\n': escapedValue.Append("\\n"); break;
+                    case '\r': escapedValue.Append("\\r"); break;
+                    case '\t': escapedValue.Append("\\t"); break;
+                    default: escapedValue.AppendChar((char)c); break;
+                }
+            }
+        }
+
+        return escapedValue;
+    }
 }

--- a/Common/Helpers.cpp
+++ b/Common/Helpers.cpp
@@ -266,26 +266,28 @@ namespace Helpers
         for (auto i = 0; i < value.GetLength(); i++)
         {
             auto c = value[i];
-            if (c > 126)
+            switch (c)
             {
-                CStringA charLiteral;
-                charLiteral.Format("\\u%04x", c);
-                escapedValue.Append(charLiteral);
-            }
-            else
-            {
-                switch (c)
-                {
-                    case '\\': escapedValue.Append("\\\\"); break;
-                    case '\"': escapedValue.Append("\\\""); break;
-                    case '/': escapedValue.Append("\\/"); break;
-                    case '\b': escapedValue.Append("\\b"); break;
-                    case '\f': escapedValue.Append("\\f"); break;
-                    case '\n': escapedValue.Append("\\n"); break;
-                    case '\r': escapedValue.Append("\\r"); break;
-                    case '\t': escapedValue.Append("\\t"); break;
-                    default: escapedValue.AppendChar((char)c); break;
-                }
+                case '\\': escapedValue.Append("\\\\"); break;
+                case '\"': escapedValue.Append("\\\""); break;
+                case '/': escapedValue.Append("\\/"); break;
+                case '\b': escapedValue.Append("\\b"); break;
+                case '\f': escapedValue.Append("\\f"); break;
+                case '\n': escapedValue.Append("\\n"); break;
+                case '\r': escapedValue.Append("\\r"); break;
+                case '\t': escapedValue.Append("\\t"); break;
+                default:
+                    if (c < 0x20 || c > 0x7e)
+                    {
+                        CStringA charLiteral;
+                        charLiteral.Format("\\u%04x", c);
+                        escapedValue.Append(charLiteral);
+                    }
+                    else
+                    {
+                        escapedValue.AppendChar(c);
+                    }
+                    break;
             }
         }
 

--- a/Common/Helpers.cpp
+++ b/Common/Helpers.cpp
@@ -285,7 +285,7 @@ namespace Helpers
                     }
                     else
                     {
-                        escapedValue.AppendChar(c);
+                        escapedValue.AppendChar((char)c);
                     }
                     break;
             }

--- a/Common/Helpers.h
+++ b/Common/Helpers.h
@@ -28,4 +28,6 @@ namespace Helpers
     static UINT s_getHtmlDocumentMessage;
 
     HRESULT StartDiagnosticsMode(_In_ IHTMLDocument2* pDocument, REFCLSID clsid, _In_ LPCWSTR path, REFIID iid, _COM_Outptr_opt_ void** ppOut);
+
+    CStringA EscapeJsonString(_In_ const CString& value);
 }

--- a/IEDiagnosticsAdapter/IEDiagnosticsAdapter.cpp
+++ b/IEDiagnosticsAdapter/IEDiagnosticsAdapter.cpp
@@ -355,7 +355,7 @@ void IEDiagnosticsAdapter::OnHttp(websocketpp::connection_hdl hdl)
             url.Replace(" ", "%20");
             url.Replace("file://", "file:///");
             CStringA title = Helpers::EscapeJsonString(it.second.title);
-            CStringA fileName(::PathFindFileNameW(it.second.filePath));
+            CStringA fileName = Helpers::EscapeJsonString(::PathFindFileNameW(it.second.filePath));
             CComBSTR guidBSTR(it.second.guid);
             CStringA guid(guidBSTR);
             guid = guid.Mid(1, guid.GetLength() - 2);

--- a/IEDiagnosticsAdapter/IEDiagnosticsAdapter.cpp
+++ b/IEDiagnosticsAdapter/IEDiagnosticsAdapter.cpp
@@ -354,7 +354,7 @@ void IEDiagnosticsAdapter::OnHttp(websocketpp::connection_hdl hdl)
             url.Replace('\\', '/');
             url.Replace(" ", "%20");
             url.Replace("file://", "file:///");
-            CStringA title(it.second.title);
+            CStringA title = Helpers::EscapeJsonString(it.second.title);
             CStringA fileName(::PathFindFileNameW(it.second.filePath));
             CComBSTR guidBSTR(it.second.guid);
             CStringA guid(guidBSTR);


### PR DESCRIPTION
When a target list JSON string contains Unicode characters or Control characters(\n,\r...),  JSON is invalid and a browser causes parsing error.
Some special characters must be escaped in JSON string values.