### PR TITLE
Fix Issue 39

### DIFF
--- a/Common/Helpers.cpp
+++ b/Common/Helpers.cpp
@@ -295,10 +295,10 @@ namespace Helpers
         return escapedValue;
     }
 
-    CStringA GetFileVersion(_In_ LPCSTR filePath)
+    CStringA GetFileVersion(_In_ LPCWSTR filePath)
     {
         ::SetLastError(0);
-        DWORD  verSize = ::GetFileVersionInfoSizeA(filePath, NULL);   
+        DWORD  verSize = ::GetFileVersionInfoSizeW(filePath, NULL);   
         if (::GetLastError() != 0 || verSize == NULL || verSize == 0)
         {
             return "";
@@ -306,14 +306,14 @@ namespace Helpers
 
         std::vector<char> verData(verSize);
 
-        if (!::GetFileVersionInfoA(filePath, NULL, verSize, &verData[0]))
+        if (!::GetFileVersionInfoW(filePath, NULL, verSize, &verData[0]))
         {
             return "";
         }
 
-        VS_FIXEDFILEINFO* verInfo = 0;
+        VS_FIXEDFILEINFO* pVerInfo = nullptr;
         UINT sizeOfVersionNumber;
-        if (!::VerQueryValueA(&verData[0], "\\", (LPVOID*)&verInfo, &sizeOfVersionNumber))
+        if (!::VerQueryValueW(&verData[0], L"\\", (LPVOID*)&pVerInfo, &sizeOfVersionNumber))
         {
             return "";
         }
@@ -326,19 +326,19 @@ namespace Helpers
         // The signature value should always be 0xFEEF04BD according to MSDN
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ms646997(v=vs.85).aspx
         // Though checking in case it's not as the bitwise operators below won't work if not
-        if (verInfo->dwSignature != VERSION_SIGNATURE)
+        if (pVerInfo->dwSignature != VERSION_SIGNATURE)
         {
             return "";
         }
 
         std::stringstream ss;
-        ss << ((verInfo->dwFileVersionMS >> 16) & 0xffff);
+        ss << ((pVerInfo->dwFileVersionMS >> 16) & 0xffff);
         ss << ".";
-        ss << ((verInfo->dwFileVersionMS >> 0) & 0xffff);
+        ss << ((pVerInfo->dwFileVersionMS >> 0) & 0xffff);
         ss << ".";
-        ss << ((verInfo->dwFileVersionLS >> 16) & 0xffff);
+        ss << ((pVerInfo->dwFileVersionLS >> 16) & 0xffff);
         ss << ".";
-        ss << ((verInfo->dwFileVersionLS >> 0) & 0xffff);
+        ss << ((pVerInfo->dwFileVersionLS >> 0) & 0xffff);
                 
         return ss.str().c_str();
     }

--- a/Common/Helpers.cpp
+++ b/Common/Helpers.cpp
@@ -299,27 +299,28 @@ namespace Helpers
     {
         ::SetLastError(0);
         DWORD  verSize = ::GetFileVersionInfoSizeA(filePath, NULL);   
-        if (::GetLastError() != 0 && verSize == NULL && verSize == 0)
+        if (::GetLastError() != 0 || verSize == NULL || verSize == 0)
         {
-            return NULL;
+            return "";
         }
+
         std::vector<char> verData(verSize);
 
         if (!::GetFileVersionInfoA(filePath, NULL, verSize, &verData[0]))
         {
-            return NULL;
+            return "";
         }
 
-        VS_FIXEDFILEINFO* verInfo = nullptr;
+        VS_FIXEDFILEINFO* verInfo = 0;
         UINT sizeOfVersionNumber;
         if (!::VerQueryValueA(&verData[0], "\\", (LPVOID*)&verInfo, &sizeOfVersionNumber))
         {
-            return NULL;
+            return "";
         }
 
         if (sizeOfVersionNumber <= 0)
         {
-            return NULL;
+            return "";
         }
         
         // The signature value should always be 0xFEEF04BD according to MSDN
@@ -327,10 +328,10 @@ namespace Helpers
         // Though checking in case it's not as the bitwise operators below won't work if not
         if (verInfo->dwSignature != VERSION_SIGNATURE)
         {
-            return NULL;
+            return "";
         }
 
-        std::stringstream  ss;
+        std::stringstream ss;
         ss << ((verInfo->dwFileVersionMS >> 16) & 0xffff);
         ss << ".";
         ss << ((verInfo->dwFileVersionMS >> 0) & 0xffff);

--- a/Common/Helpers.h
+++ b/Common/Helpers.h
@@ -30,5 +30,5 @@ namespace Helpers
     HRESULT StartDiagnosticsMode(_In_ IHTMLDocument2* pDocument, REFCLSID clsid, _In_ LPCWSTR path, REFIID iid, _COM_Outptr_opt_ void** ppOut);
 
     CStringA EscapeJsonString(_In_ const CString& value);
-    CStringA GetFileVersion(_In_ LPCSTR filePath);
+    CStringA GetFileVersion(_In_ LPCWSTR filePath);
 }

--- a/Common/Helpers.h
+++ b/Common/Helpers.h
@@ -30,5 +30,5 @@ namespace Helpers
     HRESULT StartDiagnosticsMode(_In_ IHTMLDocument2* pDocument, REFCLSID clsid, _In_ LPCWSTR path, REFIID iid, _COM_Outptr_opt_ void** ppOut);
 
     CStringA EscapeJsonString(_In_ const CString& value);
-    CStringA GetFileVersion(_In_ LPCSTR filePath);
+    CStringA GetFileVersion(_In_ CStringA filePath);
 }

--- a/Common/Helpers.h
+++ b/Common/Helpers.h
@@ -30,5 +30,5 @@ namespace Helpers
     HRESULT StartDiagnosticsMode(_In_ IHTMLDocument2* pDocument, REFCLSID clsid, _In_ LPCWSTR path, REFIID iid, _COM_Outptr_opt_ void** ppOut);
 
     CStringA EscapeJsonString(_In_ const CString& value);
-    CStringA GetFileVersion(_In_ CStringA filePath);
+    CStringA GetFileVersion(_In_ LPCSTR filePath);
 }

--- a/IEDiagnosticsAdapter/WebSocketHandler.cpp
+++ b/IEDiagnosticsAdapter/WebSocketHandler.cpp
@@ -124,7 +124,7 @@ void WebSocketHandler::OnHttp(websocketpp::connection_hdl hdl)
     else if (requestedResource == "/json/version")
     {
         // To do: This will need to change to support Edge 
-        CStringA ieVersion = Helpers::GetFileVersion("C:\\Windows\\System32\\mshtml.dll");
+        CStringA ieVersion = Helpers::GetFileVersion(L"C:\\Windows\\System32\\mshtml.dll");
         CStringA browser = "Internet Explorer " + ieVersion;
         browser = Helpers::EscapeJsonString(CString(browser));
 


### PR DESCRIPTION
Fixes a crash in json/version per issue #39.

Example output:
{
   "Browser" : "Internet Explorer 11.0.9600.17924"
   "Protocol-Version" : "1.1"
   "User-Agent" : "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; Tablet PC 2.0; InfoPath.3)"
   "WebKit-Version" : "0"
}