### PR TITLE
Returning false for canSetScriptSource.

### DIFF
--- a/IEWebKitImpl/debugger.ts
+++ b/IEWebKitImpl/debugger.ts
@@ -503,6 +503,11 @@ module Proxy {
 
             switch (method) {
                 case "canSetScriptSource":
+                    processedResult = {
+                        result: {
+                            result: false
+                        }
+                    };
                     break;
 
                 case "continueToLocation":


### PR DESCRIPTION
Currently IE11 (the current target for the adapter) doesn't support editing of running documents so returning false for the API debugger.canSetScriptSource so that tools can no they can't try editing source. Related to issue #46.

Only tried in the Chrome Dev Tools client. 